### PR TITLE
Fix unit of reported discharge rate

### DIFF
--- a/batdistrack
+++ b/batdistrack
@@ -23,7 +23,7 @@ elif [ "${1}" == "post" ]; then
 			dis=$(bc <<< "scale=5;($cdiff/1000000)/$tdiff")
 
 			date -d@$tsdiff -u +"Suspend duration: %Hh %Mm."
-			echo Discharge rate: $dis W/h.
+			echo Discharge rate: $dis W.
 		done < $FILE
 		rm $FILE
 	fi


### PR DESCRIPTION
The script reports the discharge rate (=power) in units of `W/h` (Watt per hour), which doesn't make sense.

Rather, [power](https://en.wikipedia.org/wiki/Power_(physics)) has units of `W` (Watt), and [energy](https://en.wikipedia.org/wiki/Units_of_energy) has units of `Wh` (Watt-hour). `W/h` would be a rate of change in power.

One can also see this from `/sys/class/power_supply/BAT0/energy_now`, which reports the current energy state of the battery in units of `µWh`, so when dividing by the time elapsed in hours and by 10^6 (which is what the script does), one arrives at a unit of `W`.